### PR TITLE
Exception-catching monkey-patching approach to argparse extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDE
+.idea
+


### PR DESCRIPTION
This approach passes a monkey-patched version of argparse to the
executing script that raises an exception when it hits `parse_args()`.

Scripts are able to execute normally up to that point meaning all
kinds of imports and weird script constructions and other things
should work just fine.

On hitting `parse_args` an exception is raised passing in the 
current argument parser. This is then extracted out of the
exception back in clinto.
