### PR TITLE
Generic parsing restructuring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDE
+.idea

--- a/clinto/parser.py
+++ b/clinto/parser.py
@@ -38,3 +38,10 @@ class Parser(object):
             return self.parser.is_valid
 
         return False
+
+    @property
+    def error(self):
+        if self.parser:
+            return self.parser.error
+
+        return False

--- a/clinto/parser.py
+++ b/clinto/parser.py
@@ -15,11 +15,13 @@ class Parser(object):
         with open(script_path, 'r') as f:
             script_source = f.read()
 
-        for pc in parsers:
-            parser = pc(script_path, script_source)
-            if parser.is_valid:
+        parser_obj = [pc(script_path, script_source) for pc in parsers]
+        parser_obj = sorted(parser_obj, key=lambda x: x.score, reverse=True)
+
+        for po in parser_obj:
+            if po.is_valid:
                 # It worked
-                self.parser = parser
+                self.parser = po
 
     def get_script_description(self):
         if self.parser:

--- a/clinto/parser.py
+++ b/clinto/parser.py
@@ -1,233 +1,31 @@
-from __future__ import absolute_import
-import argparse
-import sys
-import json
-import imp
-import traceback
-import tempfile
-import six
-import copy
-import types
-from collections import OrderedDict
-from itertools import chain
-from .ast import source_parser
-from .utils import is_upload, expand_iterable
+from .parsers import ArgParseParser
 
-# input attributes we try to set:
-# checked, name, type, value
-# extra information we want to append:
-# help,
-# required,
-# param (for executing the script and knowing if we need - or --),
-# upload (boolean providing info on whether it's a file are we uploading or saving)
-# choices (for selections)
-# choice_limit (for multi selection)
+parsers = [
+    ArgParseParser,
 
-CHOICE_LIMIT_MAP = {'?': '1', '+': '>=1', '*': '>=0'}
-
-# We want to map to model fields as well as html input types we encounter in argparse
-# keys are known variable types, as defined in __builtins__
-# the model is a Django based model, which can be fitted in the future for other frameworks.
-# The type is the HTML input type
-# nullcheck is a function to determine if the default value should be checked  (for cases like default='' for strings)
-# the attr_kwargs is a mapping of the action attributes to its related html input type. It is a dict
-# of the form: {'name_for_html_input': {
-# and either one or both of:
-#  'action_name': 'attribute_name_on_action', 'callback': 'function_to_evaluate_action_and_return_value'} }
-
-GLOBAL_ATTRS = ['model', 'type']
-
-
-GLOBAL_ATTR_KWARGS = {
-    'name': {'action_name': 'dest'},
-    'value': {'action_name': 'default'},
-    'required': {'action_name': 'required'},
-    'help': {'action_name': 'help'},
-    'param': {'callback': lambda x: x.option_strings[0] if x.option_strings else ''},
-    'choices': {'callback': lambda x: expand_iterable(x.choices)},
-    'choice_limit': {'callback': lambda x: CHOICE_LIMIT_MAP.get(x.nargs, x.nargs)}
-    }
-TYPE_FIELDS = {
-    # Python Builtins
-    bool: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.default is None,
-           'attr_kwargs': GLOBAL_ATTR_KWARGS},
-    float: {'model': 'FloatField', 'type': 'text', 'html5-type': 'number', 'nullcheck': lambda x: x.default is None,
-            'attr_kwargs': GLOBAL_ATTR_KWARGS},
-    int: {'model': 'IntegerField', 'type': 'text', 'nullcheck': lambda x: x.default is None,
-          'attr_kwargs': GLOBAL_ATTR_KWARGS},
-    None: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.default is None,
-          'attr_kwargs': GLOBAL_ATTR_KWARGS},
-    str: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.default == '' or x.default is None,
-          'attr_kwargs': GLOBAL_ATTR_KWARGS},
-
-    # argparse Types
-    argparse.FileType: {'model': 'FileField', 'type': 'file', 'nullcheck': lambda x: False,
-                        'attr_kwargs': dict(GLOBAL_ATTR_KWARGS, **{
-                            'value': None,
-                            'required': {'callback': lambda x: x.required or x.default in (sys.stdout, sys.stdin)},
-                            'upload': {'callback': is_upload}
-                        })},
-}
-
-if six.PY2:
-    TYPE_FIELDS.update({
-        file: {'model': 'FileField', 'type': 'file', 'nullcheck': lambda x: False,
-           'attr_kwargs': GLOBAL_ATTR_KWARGS},
-        unicode: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.default == '' or x.default is None,
-              'attr_kwargs': GLOBAL_ATTR_KWARGS},
-    })
-elif six.PY3:
-    import io
-    TYPE_FIELDS.update({
-        io.IOBase: {'model': 'FileField', 'type': 'file', 'nullcheck': lambda x: False,
-           'attr_kwargs': GLOBAL_ATTR_KWARGS},
-    })
-
-def update_dict_copy(a, b):
-    temp = copy.deepcopy(a)
-    temp.update(b)
-    return temp
-
-# There are cases where we can glean additional information about the form structure, e.g.
-# a StoreAction with default=True can be different than a StoreTrueAction with default=False
-ACTION_CLASS_TO_TYPE_FIELD = {
-    argparse._StoreAction: update_dict_copy(TYPE_FIELDS, {}),
-    argparse._StoreConstAction: update_dict_copy(TYPE_FIELDS, {}),
-    argparse._StoreTrueAction: update_dict_copy(TYPE_FIELDS, {
-        None: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.default is None,
-               'attr_kwargs': update_dict_copy(GLOBAL_ATTR_KWARGS, {
-                    'checked': {'callback': lambda x: x.default},
-                    'value': None,
-                    })
-               },
-    }),
-    argparse._StoreFalseAction: update_dict_copy(TYPE_FIELDS, {
-        None: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.default is None,
-               'attr_kwargs': update_dict_copy(GLOBAL_ATTR_KWARGS, {
-                    'checked': {'callback': lambda x: x.default},
-                    'value': None,
-                    })
-               },
-    })
-}
-
-class ArgParseNode(object):
-    """
-        This class takes an argument parser entry and assigns it to a Build spec
-    """
-    def __init__(self, action=None):
-        fields = ACTION_CLASS_TO_TYPE_FIELD.get(type(action), TYPE_FIELDS)
-        field_type = fields.get(action.type)
-        if field_type is None:
-            field_types = [i for i in fields.keys() if i is not None and issubclass(type(action.type), i)]
-            if len(field_types) > 1:
-                field_types = [i for i in fields.keys() if i is not None and isinstance(action.type, i)]
-            if len(field_types) == 1:
-                field_type = fields[field_types[0]]
-        self.node_attrs = dict([(i, field_type[i]) for i in GLOBAL_ATTRS])
-        null_check = field_type['nullcheck'](action)
-        for attr, attr_dict in six.iteritems(field_type['attr_kwargs']):
-            if attr_dict is None:
-                continue
-            if attr == 'value' and null_check:
-                continue
-            if 'action_name' in attr_dict:
-                self.node_attrs[attr] = getattr(action, attr_dict['action_name'])
-            elif 'callback' in attr_dict:
-                self.node_attrs[attr] = attr_dict['callback'](action)
-
-    @property
-    def name(self):
-        return self.node_attrs.get('name')
-
-    def __str__(self):
-        return json.dumps(self.node_attrs)
-
-    def to_django(self):
-        """
-         This is a debug function to see what equivalent django models are being generated
-        """
-        exclude = {'name', 'model'}
-        field_module = 'models'
-        django_kwargs = {}
-        if self.node_attrs['model'] == 'CharField':
-            django_kwargs['max_length'] = 255
-        django_kwargs['blank'] = not self.node_attrs['required']
-        try:
-            django_kwargs['default'] = self.node_attrs['value']
-        except KeyError:
-            pass
-        return u'{0} = {1}.{2}({3})'.format(self.node_attrs['name'], field_module, self.node_attrs['model'],
-                                           ', '.join(['{0}={1}'.format(i,v) for i,v in six.iteritems(django_kwargs)]),)
+]
 
 
 class Parser(object):
-    def __init__(self, script_path=None, script_name=None, parsers=None):
-        self.valid = False
-        self.error = ''
-        if parsers is None:
-            parsers = []
-            try:
-                module = imp.load_source(script_name, script_path)
-            except:
-                sys.stderr.write('Error while loading {0}:\n'.format(script_path))
-                self.error = '{0}\n'.format(traceback.format_exc())
-                sys.stderr.write(self.error)
-            else:
-                main_module = module.main.__globals__ if hasattr(module, 'main') else globals()
-                parsers = [v for i, v in chain(six.iteritems(main_module), six.iteritems(vars(module)))
-                           if issubclass(type(v), argparse.ArgumentParser)]
-            if not parsers:
-                f = tempfile.NamedTemporaryFile()
-                try:
-                    ast_source = source_parser.parse_source_file(script_path)
-                    python_code = source_parser.convert_to_python(list(ast_source))
-                    f.write(six.b('\n'.join(python_code)))
-                    f.seek(0)
-                    module = imp.load_source(script_name, f.name)
-                except:
-                    sys.stderr.write('Error while converting {0} to ast:\n'.format(script_path))
-                    self.error = '{0}\n'.format(traceback.format_exc())
-                    sys.stderr.write(self.error)
-                else:
-                    main_module = module.main.__globals__ if hasattr(module, 'main') else globals()
-                    parsers = [v for i, v in chain(six.iteritems(main_module), six.iteritems(vars(module)))
-                           if issubclass(type(v), argparse.ArgumentParser)]
-            if not parsers:
-                sys.stderr.write('Unable to identify ArgParser for {0}:\n'.format(script_path))
-                return
-        self.valid = True
-        parser = parsers[0]
-        self.class_name = script_name
-        self.script_path = script_path
-        self.script_description = getattr(parser, 'description', None)
-        self.script_groups = []
-        self.nodes = OrderedDict()
-        self.script_groups = []
-        non_req = set([i.dest for i in parser._get_optional_actions()])
-        self.optional_nodes = set([])
-        self.containers = OrderedDict()
-        for action in parser._actions:
-            # This is the help message of argparse
-            if action.default == argparse.SUPPRESS:
-                continue
-            node = ArgParseNode(action=action)
-            container = action.container.title
-            container_node = self.containers.get(container, None)
-            if container_node is None:
-                container_node = []
-                self.containers[container] = container_node
-            self.nodes[node.name] = node
-            container_node.append(node.name)
-            if action.dest in non_req:
-                self.optional_nodes.add(node.name)
+
+    def __init__(self, script_path=None):
+        self.parser = None
+
+        # Load file
+        with open(script_path, 'r') as f:
+            script_source = f.read()
+
+        for pc in parsers:
+            parser = pc(script_path, script_source)
+            if parser.is_valid:
+                # It worked
+                self.parser = parser
 
     def get_script_description(self):
-        return {'name': self.class_name, 'path': self.script_path,
-                'description': self.script_description,
-                'inputs': [{'group': container_name, 'nodes': [self.nodes[node].node_attrs for node in nodes]}
-                           for container_name, nodes in six.iteritems(self.containers)]}
+        if self.parser:
+            return self.parser.get_script_description()
 
     @property
     def json(self):
-        return json.dumps(self.get_script_description())
+        if self.parser:
+            return self.parser.json

--- a/clinto/parser.py
+++ b/clinto/parser.py
@@ -1,14 +1,14 @@
-from .parsers import ArgParseParser
+from .parsers import ArgParseParser, DocOptParser
 
 parsers = [
     ArgParseParser,
-
+    DocOptParser,
 ]
 
 
 class Parser(object):
 
-    def __init__(self, script_path=None):
+    def __init__(self, script_path=None, script_name=None):
         self.parser = None
 
         # Load file
@@ -29,3 +29,10 @@ class Parser(object):
     def json(self):
         if self.parser:
             return self.parser.json
+
+    @property
+    def valid(self):
+        if self.parser:
+            return self.parser.is_valid
+
+        return False

--- a/clinto/parser.py
+++ b/clinto/parser.py
@@ -31,17 +31,16 @@ class Parser(object):
     def json(self):
         if self.parser:
             return self.parser.json
+        return {}
 
     @property
     def valid(self):
         if self.parser:
             return self.parser.is_valid
-
         return False
 
     @property
     def error(self):
         if self.parser:
             return self.parser.error
-
-        return False
+        return ''

--- a/clinto/parsers/__init__.py
+++ b/clinto/parsers/__init__.py
@@ -1,1 +1,2 @@
-from .argparse import ArgParseParser
+from .argparse_ import ArgParseParser
+from .docopt_ import DocOptParser

--- a/clinto/parsers/__init__.py
+++ b/clinto/parsers/__init__.py
@@ -1,0 +1,1 @@
+from .argparse import ArgParseParser

--- a/clinto/parsers/argparse.py
+++ b/clinto/parsers/argparse.py
@@ -1,0 +1,255 @@
+from __future__ import absolute_import
+import argparse
+import sys
+import os
+import json
+import imp
+import traceback
+import tempfile
+import six
+from collections import OrderedDict
+from itertools import chain
+from ..ast import source_parser
+from ..utils import is_upload, expand_iterable
+from .base import BaseParser, parse_args_monkeypatch, ClintoArgumentParserException, update_dict_copy
+
+
+# input attributes we try to set:
+# checked, name, type, value
+# extra information we want to append:
+# help,
+# required,
+# param (for executing the script and knowing if we need - or --),
+# upload (boolean providing info on whether it's a file are we uploading or saving)
+# choices (for selections)
+# choice_limit (for multi selection)
+
+CHOICE_LIMIT_MAP = {'?': '1', '+': '>=1', '*': '>=0'}
+
+# We want to map to model fields as well as html input types we encounter in argparse
+# keys are known variable types, as defined in __builtins__
+# the model is a Django based model, which can be fitted in the future for other frameworks.
+# The type is the HTML input type
+# nullcheck is a function to determine if the default value should be checked  (for cases like default='' for strings)
+# the attr_kwargs is a mapping of the action attributes to its related html input type. It is a dict
+# of the form: {'name_for_html_input': {
+# and either one or both of:
+#  'action_name': 'attribute_name_on_action', 'callback': 'function_to_evaluate_action_and_return_value'} }
+
+GLOBAL_ATTRS = ['model', 'type']
+
+
+GLOBAL_ATTR_KWARGS = {
+    'name': {'action_name': 'dest'},
+    'value': {'action_name': 'default'},
+    'required': {'action_name': 'required'},
+    'help': {'action_name': 'help'},
+    'param': {'callback': lambda x: x.option_strings[0] if x.option_strings else ''},
+    'choices': {'callback': lambda x: expand_iterable(x.choices)},
+    'choice_limit': {'callback': lambda x: CHOICE_LIMIT_MAP.get(x.nargs, x.nargs)}
+    }
+
+TYPE_FIELDS = {
+    # Python Builtins
+    bool: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.default is None,
+           'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    float: {'model': 'FloatField', 'type': 'text', 'html5-type': 'number', 'nullcheck': lambda x: x.default is None,
+            'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    int: {'model': 'IntegerField', 'type': 'text', 'nullcheck': lambda x: x.default is None,
+          'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    None: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.default is None,
+          'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    str: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.default == '' or x.default is None,
+          'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    # Argparse specific type field types
+    argparse.FileType: {'model': 'FileField', 'type': 'file', 'nullcheck': lambda x: False,
+                        'attr_kwargs': dict(GLOBAL_ATTR_KWARGS, **{
+                            'value': None,
+                            'required': {'callback': lambda x: x.required or x.default in (sys.stdout, sys.stdin)},
+                            'upload': {'callback': is_upload}
+                        })},
+
+}
+
+
+if six.PY2:
+    TYPE_FIELDS.update({
+        file: {'model': 'FileField', 'type': 'file', 'nullcheck': lambda x: False,
+           'attr_kwargs': GLOBAL_ATTR_KWARGS},
+        unicode: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.default == '' or x.default is None,
+              'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    })
+elif six.PY3:
+    import io
+    TYPE_FIELDS.update({
+        io.IOBase: {'model': 'FileField', 'type': 'file', 'nullcheck': lambda x: False,
+           'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    })
+
+
+
+# There are cases where we can glean additional information about the form structure, e.g.
+# a StoreAction with default=True can be different than a StoreTrueAction with default=False
+ACTION_CLASS_TO_TYPE_FIELD = {
+    argparse._StoreAction: update_dict_copy(TYPE_FIELDS, {}),
+    argparse._StoreConstAction: update_dict_copy(TYPE_FIELDS, {}),
+    argparse._StoreTrueAction: update_dict_copy(TYPE_FIELDS, {
+        None: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.default is None,
+               'attr_kwargs': update_dict_copy(GLOBAL_ATTR_KWARGS, {
+                    'checked': {'callback': lambda x: x.default},
+                    'value': None,
+                    })
+               },
+    }),
+    argparse._StoreFalseAction: update_dict_copy(TYPE_FIELDS, {
+        None: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.default is None,
+               'attr_kwargs': update_dict_copy(GLOBAL_ATTR_KWARGS, {
+                    'checked': {'callback': lambda x: x.default},
+                    'value': None,
+                    })
+               },
+    })
+}
+
+class ArgParseNode(object):
+    """
+        This class takes an argument parser entry and assigns it to a Build spec
+    """
+    def __init__(self, action=None):
+        fields = ACTION_CLASS_TO_TYPE_FIELD.get(type(action), TYPE_FIELDS)
+        field_type = fields.get(action.type)
+        if field_type is None:
+            field_types = [i for i in fields.keys() if i is not None and issubclass(type(action.type), i)]
+            if len(field_types) > 1:
+                field_types = [i for i in fields.keys() if i is not None and isinstance(action.type, i)]
+            if len(field_types) == 1:
+                field_type = fields[field_types[0]]
+        self.node_attrs = dict([(i, field_type[i]) for i in GLOBAL_ATTRS])
+        null_check = field_type['nullcheck'](action)
+        for attr, attr_dict in six.iteritems(field_type['attr_kwargs']):
+            if attr_dict is None:
+                continue
+            if attr == 'value' and null_check:
+                continue
+            if 'action_name' in attr_dict:
+                self.node_attrs[attr] = getattr(action, attr_dict['action_name'])
+            elif 'callback' in attr_dict:
+                self.node_attrs[attr] = attr_dict['callback'](action)
+
+    @property
+    def name(self):
+        return self.node_attrs.get('name')
+
+    def __str__(self):
+        return json.dumps(self.node_attrs)
+
+    def to_django(self):
+        """
+         This is a debug function to see what equivalent django models are being generated
+        """
+        exclude = {'name', 'model'}
+        field_module = 'models'
+        django_kwargs = {}
+        if self.node_attrs['model'] == 'CharField':
+            django_kwargs['max_length'] = 255
+        django_kwargs['blank'] = not self.node_attrs['required']
+        try:
+            django_kwargs['default'] = self.node_attrs['value']
+        except KeyError:
+            pass
+        return u'{0} = {1}.{2}({3})'.format(self.node_attrs['name'], field_module, self.node_attrs['model'],
+                                           ', '.join(['{0}={1}'.format(i,v) for i,v in six.iteritems(django_kwargs)]),)
+
+
+
+class ArgParseParser(BaseParser):
+
+    extensions = ['.py']
+    contains = "ArgumentParser"
+
+    def extract_parser(self):
+        parsers = []
+
+        # Try exception-catching first; this should always work
+        # Store prior to monkeypatch to restore
+        parse_args_unmonkey = argparse.ArgumentParser.parse_args
+        argparse.ArgumentParser.parse_args = parse_args_monkeypatch
+
+        try:
+            execfile(self.script_path, {'argparse': argparse, '__name__': '__main__'})
+        except ClintoArgumentParserException as e:
+            # Catch the generated exception, passing the ArgumentParser object
+            parsers.append(e.parser)
+        except:
+            sys.stderr.write('Error while trying exception-catch method on {0}:\n'.format(self.script_path))
+            self.error = '{0}\n'.format(traceback.format_exc())
+            sys.stderr.write(self.error)
+
+        argparse.ArgumentParser.parse_args = parse_args_unmonkey
+
+        if not parsers:
+            try:
+                module = imp.load_source('__name__', self.script_path)
+            except:
+                sys.stderr.write('Error while loading {0}:\n'.format(self.script_path))
+                self.error = '{0}\n'.format(traceback.format_exc())
+                sys.stderr.write(self.error)
+            else:
+                main_module = module.main.__globals__ if hasattr(module, 'main') else globals()
+                parsers = [v for i, v in chain(six.iteritems(main_module), six.iteritems(vars(module)))
+                           if issubclass(type(v), argparse.ArgumentParser)]
+        if not parsers:
+            f = tempfile.NamedTemporaryFile()
+            try:
+                ast_source = source_parser.parse_source_file(self.script_path)
+                python_code = source_parser.convert_to_python(list(ast_source))
+                f.write(six.b('\n'.join(python_code)))
+                f.seek(0)
+                module = imp.load_source('__main__', f.name)
+            except:
+                sys.stderr.write('Error while converting {0} to ast:\n'.format(self.script_path))
+                self.error = '{0}\n'.format(traceback.format_exc())
+                sys.stderr.write(self.error)
+            else:
+                main_module = module.main.__globals__ if hasattr(module, 'main') else globals()
+                parsers = [v for i, v in chain(six.iteritems(main_module), six.iteritems(vars(module)))
+                       if issubclass(type(v), argparse.ArgumentParser)]
+        if not parsers:
+            sys.stderr.write('Unable to identify ArgParser for {0}:\n'.format(self.script_path))
+            return
+
+        self.is_valid = True
+        self.parser = parsers[0]
+
+    def process_parser(self):
+        self.class_name = os.path.splitext(os.path.basename(self.script_path))[0]
+        self.script_path = self.script_path
+        self.script_description = getattr(self.parser, 'description', None)
+        self.script_groups = []
+        self.nodes = OrderedDict()
+        self.script_groups = []
+        non_req = set([i.dest for i in self.parser._get_optional_actions()])
+        self.optional_nodes = set([])
+        self.containers = OrderedDict()
+        for action in self.parser._actions:
+            # This is the help message of argparse
+            if action.default == argparse.SUPPRESS:
+                continue
+            node = ArgParseNode(action=action)
+            container = action.container.title
+            container_node = self.containers.get(container, None)
+            if container_node is None:
+                container_node = []
+                self.containers[container] = container_node
+            self.nodes[node.name] = node
+            container_node.append(node.name)
+            if action.dest in non_req:
+                self.optional_nodes.add(node.name)
+
+    def get_script_description(self):
+        return {'name': self.class_name, 'path': self.script_path,
+                'description': self.script_description,
+                'inputs': [{'group': container_name, 'nodes': [self.nodes[node].node_attrs for node in nodes]}
+                           for container_name, nodes in six.iteritems(self.containers)]}
+
+

--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -111,6 +111,7 @@ ACTION_CLASS_TO_TYPE_FIELD = {
     })
 }
 
+
 class ArgParseNode(object):
     """
         This class takes an argument parser entry and assigns it to a Build spec

--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -183,7 +183,7 @@ class ArgParseParser(BaseParser):
         argparse.ArgumentParser.parse_args = parse_args_monkeypatch
 
         try:
-            execfile(self.script_path, {'argparse': argparse, '__name__': '__main__'})
+            exec(self.script_source, {'argparse': argparse, '__name__': '__main__'})
         except ClintoArgumentParserException as e:
             # Catch the generated exception, passing the ArgumentParser object
             parsers.append(e.parser)

--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -165,8 +165,14 @@ class ArgParseNode(object):
 
 class ArgParseParser(BaseParser):
 
-    extensions = ['.py']
-    contains = "ArgumentParser"
+    def heuristic(self):
+        return [
+            self.script_ext in ['.py', '.py3', '.py2'],
+            'argparse' in self.script_source,
+            'ArgumentParser' in self.script_source,
+            '.parse_args' in self.script_source,
+            '.add_argument' in self.script_source,
+        ]
 
     def extract_parser(self):
         parsers = []

--- a/clinto/parsers/base.py
+++ b/clinto/parsers/base.py
@@ -66,7 +66,7 @@ class BaseParser(object):
         pass
 
     def get_script_description(self):
-        pass
+        return {}
 
     @property
     def json(self):

--- a/clinto/parsers/base.py
+++ b/clinto/parsers/base.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+import json
+import os
+import copy
+
+
+def update_dict_copy(a, b):
+    temp = copy.deepcopy(a)
+    temp.update(b)
+    return temp
+
+
+class ClintoArgumentParserException(Exception):
+    def __init__(self, parser, *args, **kwargs):
+        self.parser = parser
+
+
+def parse_args_monkeypatch(self, *args, **kwargs):
+    raise ClintoArgumentParserException(self)
+
+
+class BaseParser(object):
+
+    extensions = []
+    contains = ""
+
+    def __init__(self, script_path=None, script_source=None):
+        self.is_valid = False
+        self.error = ''
+        self.parser = None
+
+        self.script_path = script_path
+        self.script_source = script_source
+
+        if not self.check_valid():
+            return
+
+        self.extract_parser()
+
+        if self.parser is None:
+            return
+
+        self.process_parser()
+
+    def check_valid(self):
+        ext = os.path.splitext(os.path.basename(self.script_path))[1]
+        return ext in self.extensions and self.contains in self.script_source
+
+    def extract_parser(self):
+        pass
+
+    def process_parser(self):
+        pass
+
+    def get_script_description(self):
+        pass
+
+    @property
+    def json(self):
+        return json.dumps(self.get_script_description())

--- a/clinto/parsers/base.py
+++ b/clinto/parsers/base.py
@@ -43,8 +43,11 @@ class BaseParser(object):
         self.process_parser()
 
     def check_valid(self):
-        ext = os.path.splitext(os.path.basename(self.script_path))[1]
-        return ext in self.extensions and self.contains in self.script_source
+        if self.script_path:
+            ext = os.path.splitext(os.path.basename(self.script_path))[1]
+            return ext in self.extensions and self.contains in self.script_source
+
+        return False
 
     def extract_parser(self):
         pass

--- a/clinto/parsers/base.py
+++ b/clinto/parsers/base.py
@@ -28,7 +28,9 @@ class BaseParser(object):
 
         self.script_path = script_path
         # We need this for heuristic, may as well happen once
-        self.script_ext = os.path.splitext(os.path.basename(self.script_path))[1]
+        if self.script_path:
+            self.script_ext = os.path.splitext(os.path.basename(self.script_path))[1]
+
         self.script_source = script_source
 
         self._heuristic_score = None

--- a/clinto/parsers/docopt_.py
+++ b/clinto/parsers/docopt_.py
@@ -71,8 +71,12 @@ class DocOptNode(object):
 
 class DocOptParser(BaseParser):
 
-    extensions = ['.py']
-    contains = "docopt"
+    def heuristic(self):
+        return [
+            self.script_ext in ['.py', '.py3', '.py2'],
+            'docopt' in self.script_source,
+            '__doc__' in self.script_source,
+        ]
 
     def extract_parser(self):
         if docopt is None:

--- a/clinto/parsers/docopt_.py
+++ b/clinto/parsers/docopt_.py
@@ -1,0 +1,161 @@
+from __future__ import absolute_import
+
+import sys
+import os
+import json
+import imp
+import inspect
+import tempfile
+import six
+from collections import OrderedDict
+from itertools import chain
+from ..ast import source_parser
+from ..utils import is_upload, expand_iterable
+from .base import BaseParser, parse_args_monkeypatch, ClintoArgumentParserException, update_dict_copy
+
+try:
+    import docopt
+except ImportError:
+    docopt = None
+
+
+GLOBAL_ATTRS = ['model', 'type']
+
+
+GLOBAL_ATTR_KWARGS = {
+    'name': {'action_name': 'dest'},
+    'value': {'action_name': 'default'},
+    'required': {'action_name': 'required'},
+    'help': {'action_name': 'help'},
+    }
+
+TYPE_FIELDS = {
+    # Python Builtins
+    bool: {'model': 'BooleanField', 'type': 'checkbox', 'nullcheck': lambda x: x.value is None,
+           'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    float: {'model': 'FloatField', 'type': 'text', 'html5-type': 'number', 'nullcheck': lambda x: x.value is None,
+            'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    int: {'model': 'IntegerField', 'type': 'text', 'nullcheck': lambda x: x.value is None,
+          'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    None: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.value is None,
+          'attr_kwargs': GLOBAL_ATTR_KWARGS},
+    str: {'model': 'CharField', 'type': 'text', 'nullcheck': lambda x: x.value == '' or x.value is None,
+          'attr_kwargs': GLOBAL_ATTR_KWARGS},
+}
+
+
+
+class DocOptNode(object):
+    """
+        This class takes an argument parser entry and assigns it to a Build spec
+    """
+    def __init__(self, name, option=None):
+        field_type = TYPE_FIELDS.get(option.type)
+        if field_type is None:
+            field_types = [i for i in fields.keys() if i is not None and issubclass(type(option.type), i)]
+            if len(field_types) > 1:
+                field_types = [i for i in fields.keys() if i is not None and isinstance(option.type, i)]
+            if len(field_types) == 1:
+                field_type = fields[field_types[0]]
+        self.node_attrs = dict([(i, field_type[i]) for i in GLOBAL_ATTRS])
+        self.node_attrs['name'] = name
+        self.node_attrs['param'] = option.long if option.long else option.short
+
+    @property
+    def name(self):
+        return self.node_attrs.get('name')
+
+    def __str__(self):
+        return json.dumps(self.node_attrs)
+
+
+class DocOptParser(BaseParser):
+
+    extensions = ['.py']
+    contains = "docopt"
+
+    def extract_parser(self):
+        if docopt is None:
+            return False
+
+        try:
+            module = imp.load_source('__name__', self.script_path)
+
+        except Exception:
+            sys.stderr.write('Error while loading {0}:\n'.format(self.script_path))
+            self.error = '{0}\n'.format(traceback.format_exc())
+            sys.stderr.write(self.error)
+            return
+
+        try:
+            doc = module.__doc__
+
+        except AttributeError:
+            return
+
+        # We have the documentation string in 'doc'
+        self.is_valid = True
+
+        # Parse and monkey patch exception catch
+
+        self.parser = doc
+
+    def process_parser(self):
+        """
+        We can't use the exception catch trick for docopt because the module prevents access to
+        it's innards __all__ = ['docopt']. Instead call with --help enforced, catch sys.exit and
+        work up to the calling docopt function to pull out the elements. This is horrible.
+
+        :return:
+        """
+
+        try:
+            # Parse with --help to enforce exit
+            usage_sections = docopt.docopt(self.parser, ['--help'])
+        except SystemExit as e:
+            parser = inspect.trace()[-2][0].f_locals
+
+        '''
+        docopt represents all values as strings and doesn't automatically cast, we probably want to do
+        some testing to see if we can convert the default value (Option.value) to a particular type.
+        '''
+
+        def guess_type(s):
+            try:
+                v = float(s)
+                v = int(s)
+                v = s
+            except ValueError:
+                pass
+
+            return type(v)
+
+        self.script_groups = ['Arguments']
+        self.nodes = OrderedDict()
+        self.containers = OrderedDict()
+        self.containers['default'] = []
+
+        for option in parser['options']:
+            if option.long in ['--help', '--version']:
+                continue
+
+            option.type = guess_type(option.value)
+            option_name = option.long.strip('-')
+            node = DocOptNode(option_name, option=option)
+
+            self.nodes[option_name] = node
+            self.containers['default'].append(option_name)
+
+
+        self.class_name = os.path.splitext(os.path.basename(self.script_path))[0]
+        self.script_path = self.script_path
+        self.script_description = self.parser
+
+
+    def get_script_description(self):
+        return {'name': self.class_name, 'path': self.script_path,
+                'description': self.script_description,
+                'inputs': [{'group': container_name, 'nodes': [self.nodes[node].node_attrs for node in nodes]}
+                           for container_name, nodes in six.iteritems(self.containers)]}
+
+

--- a/clinto/tests/test_fields.py
+++ b/clinto/tests/test_fields.py
@@ -1,8 +1,7 @@
 import unittest
 
 from . import factories
-from clinto.parser import Parser
-from clinto.parsers.argparse import ArgParseNode, expand_iterable, ArgParseParser
+from clinto.parsers.argparse_ import ArgParseNode, expand_iterable, ArgParseParser
 
 
 class Test_ArgParse(unittest.TestCase):

--- a/clinto/tests/test_fields.py
+++ b/clinto/tests/test_fields.py
@@ -37,7 +37,7 @@ class Test_ArgParse(unittest.TestCase):
 
     def test_argparse_script(self):
         parser = ArgParseParser()
-        parser.script_path = "Test"
+        parser.script_path = "test.py"
         parser.parser = self.parser.parser
         parser.process_parser()
         description = parser.get_script_description()

--- a/clinto/tests/test_fields.py
+++ b/clinto/tests/test_fields.py
@@ -1,7 +1,8 @@
 import unittest
 
 from . import factories
-from clinto.parsers.parser import ArgParseNode, Parser, expand_iterable
+from clinto.parser import Parser
+from clinto.parsers.argparse import ArgParseNode, expand_iterable, ArgParseParser
 
 
 class Test_ArgParse(unittest.TestCase):
@@ -36,7 +37,12 @@ class Test_ArgParse(unittest.TestCase):
         assert rangefield.node_attrs['choices'] == expand_iterable(self.parser.rangefield.choices)
 
     def test_argparse_script(self):
-        nodes = Parser(parsers=[self.parser.parser])
+        parser = ArgParseParser()
+        parser.script_path = "Test"
+        parser.parser = self.parser.parser
+        parser.process_parser()
+        description = parser.get_script_description()
+        nodes = description['inputs'][0]['nodes']
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Test_ArgParse)

--- a/clinto/tests/test_fields.py
+++ b/clinto/tests/test_fields.py
@@ -1,6 +1,8 @@
-import unittest, sys
+import unittest
+
 from . import factories
-from ..parser import ArgParseNode, Parser, expand_iterable
+from clinto.parsers.parser import ArgParseNode, Parser, expand_iterable
+
 
 class Test_ArgParse(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This is a zero side-effect restructuring of clinto to prepare for
other parsers. Parsers are defined off a base class which provides
a series of stub functions that must be overridden to provide
a new parser.  The initialisation of a parser accepts a script
path and source code which is then tested, first for file extension
then for the file containing a magic token (e.g. ArgumentParser) that
identifies that file as likely to be using a particular parser.

If these match the parsing is performed and the parse object parsed(!)

If this final step is sucessful parsing will halt, otherwise it will
continue on to try the next parser.

Individual parsers are isolated in separate files (e.g. argparse.py)
and are free to use their own logic and internals to generate the output.
The json output of sucessfully processed parsers is available via the
public parser.Parser class (and is the get_script_description for debug).

This incorporates the changes for exception monkey patching.
