### PR TITLE
added __file__ param to exec call

### DIFF
--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -195,7 +195,12 @@ class ArgParseParser(BaseParser):
         argparse.ArgumentParser.parse_args = parse_args_monkeypatch
 
         try:
-            exec(self.script_source, {'argparse': argparse, '__name__': '__main__'})
+            exec(
+                self.script_source,
+                {'argparse': argparse,
+                    '__name__': '__main__',
+                    '__file__': self.script_path,
+                 })
         except ClintoArgumentParserException as e:
             # Catch the generated exception, passing the ArgumentParser object
             parsers.append(e.parser)


### PR DESCRIPTION
In this way it's available when the file is executed.

Obviously `__file__` will not have the path of the original script uploaded through wooey's addscript, but it allows compatibility if the standalone file is using it. Besides, it provides a way to extract the project path directly from the script