### PR TITLE
Fix multiple param spec

### DIFF
--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -15,6 +15,7 @@ import six
 from ..ast import source_parser
 from ..utils import is_upload, expand_iterable
 from .base import BaseParser, parse_args_monkeypatch, ClintoArgumentParserException, update_dict_copy
+from .constants import SPECIFY_EVERY_PARAM
 
 
 # input attributes we try to set:
@@ -50,7 +51,7 @@ def get_parameter_action(action):
     """
     actions = set()
     if isinstance(action, argparse._AppendAction):
-        actions.add('collapse_arguments')
+        actions.add(SPECIFY_EVERY_PARAM)
     return actions
 
 GLOBAL_ATTR_KWARGS = {

--- a/clinto/parsers/constants.py
+++ b/clinto/parsers/constants.py
@@ -1,0 +1,3 @@
+# This indicates a parameter key should be specified for every argument. e.g. --foo 1 --foo 2 instead
+# of --foo 1 2
+SPECIFY_EVERY_PARAM = 'specify_every_param'

--- a/clinto/tests/test_parsers.py
+++ b/clinto/tests/test_parsers.py
@@ -5,6 +5,7 @@ import six
 from . import factories
 from clinto.version import PY_MINOR_VERSION, PY36
 from clinto.parsers.argparse_ import ArgParseNode, expand_iterable, ArgParseParser
+from clinto.parsers.constants import SPECIFY_EVERY_PARAM
 from clinto.parser import Parser
 
 
@@ -83,6 +84,16 @@ class TestArgParse(unittest.TestCase):
                 'group': 'positional arguments'
             }
         )
+
+    def test_argparse_specify_every_param(self):
+        script_path = os.path.join(self.script_dir, 'choices.py')
+        parser = Parser(script_path=script_path)
+
+        script_params = parser.get_script_description()
+        self.assertEqual(script_params['path'], script_path)
+
+        append_field = [i for i in script_params['inputs'][''][1]['nodes'] if i['param'] == '--need-at-least-one-numbers'][0]
+        self.assertIn(SPECIFY_EVERY_PARAM, append_field['param_action'])
 
     def test_function_type_script(self):
         script_path = os.path.join(self.script_dir, 'function_argtype.py')


### PR DESCRIPTION
Make it easier for 3rd party packages to detect when the 'append' flag is being utilized and add a test to ensure it is being used correctly.

Relates to https://github.com/wooey/Wooey/issues/269