### PR TITLE
Allow excluding bad imports from ast parser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Up to date compatibility matrix
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         make test
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         flags: unittests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      env:
-        DJANGO_VERSION: ${{ matrix.django-version }}
       run: |
         python -m pip install --upgrade pip
         make testenv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/psf/black
-    sha: 19.3b0
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
     -   id: black

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ testenv:
 	pip install -e .
 
 test:
-	nosetests --with-coverage --cover-erase --cover-branches --cover-package=clinto clinto/tests/*
+	pytest --cov=clinto --cov-config=.coveragerc clinto/tests/*
 	coverage report --omit='clinto/tests*'
 	coverage xml --omit='clinto/tests*'
 

--- a/clinto/ast/source_parser.py
+++ b/clinto/ast/source_parser.py
@@ -1,11 +1,11 @@
-'''
+"""
 Created on Dec 11, 2013
 
 @author: Chris
 
 Collection of functions for extracting argparse related statements from the 
 client code.
-'''
+"""
 
 import ast
 import _ast
@@ -14,7 +14,19 @@ from itertools import *
 from . import codegen
 
 
-def parse_source_file(file_name):
+def find_valid_imports(imports):
+    valid_imports = []
+    for import_module in imports:
+        try:
+            exec(codegen.to_source(import_module))
+        except (ImportError, ModuleNotFoundError):
+            pass
+        else:
+            valid_imports.append(import_module)
+    return valid_imports
+
+
+def parse_source_file(file_name, ignore_bad_imports=False):
     """
     Parses the AST of Python file for lines containing
     references to the argparse module.
@@ -35,7 +47,7 @@ def parse_source_file(file_name):
       * parser_var_name                    The instance variable of the ArgumentParser (line 1 in example code)
       * ast_source                            The curated collection of all parser related nodes in the client code
     """
-    with open(file_name, 'r') as f:
+    with open(file_name, "r") as f:
         s = f.read()
 
     nodes = ast.parse(s)
@@ -43,32 +55,54 @@ def parse_source_file(file_name):
     module_imports = get_nodes_by_instance_type(nodes, _ast.Import)
     specific_imports = get_nodes_by_instance_type(nodes, _ast.ImportFrom)
 
+    if ignore_bad_imports:
+        module_imports = find_valid_imports(module_imports)
+        specific_imports = find_valid_imports(specific_imports)
+
     assignment_objs = get_nodes_by_instance_type(nodes, _ast.Assign)
     call_objects = get_nodes_by_instance_type(nodes, _ast.Call)
 
-    argparse_assignments = get_nodes_by_containing_attr(assignment_objs, 'ArgumentParser')
-    group_arg_assignments = get_nodes_by_containing_attr(assignment_objs, 'add_argument_group')
-    add_arg_assignments = get_nodes_by_containing_attr(call_objects, 'add_argument')
-    parse_args_assignment = get_nodes_by_containing_attr(call_objects, 'parse_args')
+    argparse_assignments = get_nodes_by_containing_attr(
+        assignment_objs, "ArgumentParser"
+    )
+    group_arg_assignments = get_nodes_by_containing_attr(
+        assignment_objs, "add_argument_group"
+    )
+    add_arg_assignments = get_nodes_by_containing_attr(call_objects, "add_argument")
+    parse_args_assignment = get_nodes_by_containing_attr(call_objects, "parse_args")
     # there are cases where we have custom argparsers, such as subclassing ArgumentParser. The above
     # will fail on this. However, we can use the methods known to ArgumentParser to do a duck-type like
     # approach to finding what is the arg parser
     if not argparse_assignments:
-        aa_references = set([i.func.value.id for i in chain(add_arg_assignments, parse_args_assignment)])
-        argparse_like_objects = [getattr(i.value.func, 'id', None) for p_ref in aa_references for i in get_nodes_by_containing_attr(assignment_objs, p_ref)]
+        aa_references = set(
+            [i.func.value.id for i in chain(add_arg_assignments, parse_args_assignment)]
+        )
+        argparse_like_objects = [
+            getattr(i.value.func, "id", None)
+            for p_ref in aa_references
+            for i in get_nodes_by_containing_attr(assignment_objs, p_ref)
+        ]
         argparse_like_objects = filter(None, argparse_like_objects)
-        argparse_assignments = [get_nodes_by_containing_attr(assignment_objs, i) for i in argparse_like_objects]
+        argparse_assignments = [
+            get_nodes_by_containing_attr(assignment_objs, i)
+            for i in argparse_like_objects
+        ]
         # for now, we just choose one
         try:
             argparse_assignments = argparse_assignments[0]
         except IndexError:
             pass
 
-
     # get things that are assigned inside ArgumentParser or its methods
-    argparse_assigned_variables = get_node_args_and_keywords(assignment_objs, argparse_assignments, 'ArgumentParser')
-    add_arg_assigned_variables = get_node_args_and_keywords(assignment_objs, add_arg_assignments, 'add_argument')
-    parse_args_assigned_variables = get_node_args_and_keywords(assignment_objs, parse_args_assignment, 'parse_args')
+    argparse_assigned_variables = get_node_args_and_keywords(
+        assignment_objs, argparse_assignments, "ArgumentParser"
+    )
+    add_arg_assigned_variables = get_node_args_and_keywords(
+        assignment_objs, add_arg_assignments, "add_argument"
+    )
+    parse_args_assigned_variables = get_node_args_and_keywords(
+        assignment_objs, parse_args_assignment, "parse_args"
+    )
 
     ast_argparse_source = chain(
         module_imports,
@@ -84,7 +118,7 @@ def parse_source_file(file_name):
 
 
 def read_client_module(filename):
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         return f.readlines()
 
 
@@ -94,14 +128,14 @@ def get_node_args_and_keywords(assigned_objs, assignments, selector=None):
     assignment_nodes = []
     for node in assignments:
         for i in walk_tree(node):
-            if i and isinstance(i, (_ast.keyword, _ast.Name)) and 'id' in i.__dict__:
+            if i and isinstance(i, (_ast.keyword, _ast.Name)) and "id" in i.__dict__:
                 if i.id == selector:
                     selector_line = i.lineno
                 elif i.lineno == selector_line:
                     referenced_nodes.add(i.id)
     for node in assigned_objs:
         for target in node.targets:
-            if getattr(target, 'id', None) in referenced_nodes:
+            if getattr(target, "id", None) in referenced_nodes:
                 assignment_nodes.append(node)
     return assignment_nodes
 

--- a/clinto/parser.py
+++ b/clinto/parser.py
@@ -8,7 +8,7 @@ parsers = [ArgParseParser, DocOptParser]
 
 
 class Parser(object):
-    def __init__(self, script_path=None, script_name=None):
+    def __init__(self, script_path=None, script_name=None, ignore_bad_imports=False):
         self.parser = None
         self._error = ""
 
@@ -22,7 +22,12 @@ class Parser(object):
             script_source = f.read()
 
         parser_obj = [
-            pc(script_path=script_path, script_source=script_source) for pc in parsers
+            pc(
+                script_path=script_path,
+                script_source=script_source,
+                ignore_bad_imports=ignore_bad_imports,
+            )
+            for pc in parsers
         ]
         parser_obj = sorted(parser_obj, key=lambda x: x.score, reverse=True)
 

--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -202,7 +202,7 @@ ACTION_CLASS_TO_TYPE_FIELD = {
 
 class ArgParseNode(object):
     """
-     This class takes an argument parser entry and assigns it to a Build spec
+    This class takes an argument parser entry and assigns it to a Build spec
     """
 
     def __init__(self, action=None, mutex_group=None):
@@ -250,7 +250,7 @@ class ArgParseNode(object):
 
     def to_django(self):
         """
-         This is a debug function to see what equivalent django models are being generated
+        This is a debug function to see what equivalent django models are being generated
         """
         exclude = {"name", "model"}
         field_module = "models"
@@ -262,7 +262,7 @@ class ArgParseNode(object):
             django_kwargs["default"] = self.node_attrs["value"]
         except KeyError:
             pass
-        return u"{0} = {1}.{2}({3})".format(
+        return "{0} = {1}.{2}({3})".format(
             self.node_attrs["name"],
             field_module,
             self.node_attrs["model"],
@@ -335,7 +335,9 @@ class ArgParseParser(BaseParser):
         if not parsers:
             f = tempfile.NamedTemporaryFile()
             try:
-                ast_source = source_parser.parse_source_file(self.script_path)
+                ast_source = source_parser.parse_source_file(
+                    self.script_path, ignore_bad_imports=self.ignore_bad_imports
+                )
                 python_code = source_parser.convert_to_python(list(ast_source))
                 f.write(six.b("\n".join(python_code)))
                 f.seek(0)

--- a/clinto/parsers/argparse_.py
+++ b/clinto/parsers/argparse_.py
@@ -333,15 +333,15 @@ class ArgParseParser(BaseParser):
                     if issubclass(type(v), argparse.ArgumentParser)
                 ]
         if not parsers:
-            f = tempfile.NamedTemporaryFile()
             try:
-                ast_source = source_parser.parse_source_file(
-                    self.script_path, ignore_bad_imports=self.ignore_bad_imports
-                )
-                python_code = source_parser.convert_to_python(list(ast_source))
-                f.write(six.b("\n".join(python_code)))
-                f.seek(0)
+                with tempfile.NamedTemporaryFile(delete=False) as f:
+                    ast_source = source_parser.parse_source_file(
+                        self.script_path, ignore_bad_imports=self.ignore_bad_imports
+                    )
+                    python_code = source_parser.convert_to_python(list(ast_source))
+                    f.write(six.b("\n".join(python_code)))
                 module = imp.load_source("__main__", f.name)
+                os.remove(f.name)
             except Exception:
                 sys.stderr.write(
                     "Error while converting {0} to ast:\n".format(self.script_path)

--- a/clinto/parsers/base.py
+++ b/clinto/parsers/base.py
@@ -30,10 +30,11 @@ def parse_args_monkeypatch(self, *args, **kwargs):
 
 
 class BaseParser(object):
-    def __init__(self, script_path=None, script_source=None):
+    def __init__(self, script_path=None, script_source=None, ignore_bad_imports=False):
         self.is_valid = False
         self.error = ""
         self.parser = None
+        self.ignore_bad_imports = ignore_bad_imports
 
         self.script_path = script_path
         # We need this for heuristic, may as well happen once

--- a/clinto/tests/argparse_scripts/error_script.py
+++ b/clinto/tests/argparse_scripts/error_script.py
@@ -2,7 +2,8 @@ import argparse
 import something_i_dont_have
 
 parser = argparse.ArgumentParser(description="Something")
+parser.add_argument("-foo")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parser.parse_args()
-    sys.stdout.write('{}'.format(args))
+    sys.stdout.write("{}".format(args))

--- a/clinto/tests/test_parsers.py
+++ b/clinto/tests/test_parsers.py
@@ -182,6 +182,32 @@ class TestArgParse(unittest.TestCase):
         parser = Parser(script_path=script_path)
         self.assertEquals("", parser.error)
 
+    def test_can_exclude_bad_imports(self):
+        script_path = os.path.join(self.script_dir, "error_script.py")
+        parser = Parser(script_path=script_path, ignore_bad_imports=True)
+        self.assertEquals("", parser.error)
+        script_params = parser.get_script_description()
+        self.assertDictEqual(
+            script_params["inputs"][""][0],
+            {
+                "group": "optional arguments",
+                "nodes": [
+                    {
+                        "model": "CharField",
+                        "type": "text",
+                        "mutex_group": {},
+                        "name": "foo",
+                        "required": False,
+                        "help": None,
+                        "param": "-foo",
+                        "param_action": set(),
+                        "choices": None,
+                        "choice_limit": None,
+                    }
+                ],
+            },
+        )
+
     def test_zipapp(self):
         script_path = os.path.join(self.script_dir, "data_reader.zip")
         parser = Parser(script_path=script_path)

--- a/clinto/tests/test_parsers.py
+++ b/clinto/tests/test_parsers.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import unittest
 
@@ -7,6 +8,9 @@ from clinto.version import PY_MINOR_VERSION, PY36
 from clinto.parsers.argparse_ import ArgParseNode, expand_iterable, ArgParseParser
 from clinto.parsers.constants import SPECIFY_EVERY_PARAM
 from clinto.parser import Parser
+
+_parser = argparse.ArgumentParser()
+OPTIONAL_TITLE = _parser._optionals.title
 
 
 class TestArgParse(unittest.TestCase):
@@ -31,7 +35,7 @@ class TestArgParse(unittest.TestCase):
         main_parser = description["inputs"][""]
         main_parser_group1 = main_parser[0]
         self.assertEqual(main_parser_group1["nodes"][0]["name"], "test_arg")
-        self.assertEqual(main_parser_group1["group"], "optional arguments")
+        self.assertEqual(main_parser_group1["group"], OPTIONAL_TITLE)
 
         subparser1 = description["inputs"]["subparser1"]
         subparser_group1 = subparser1[0]
@@ -191,7 +195,7 @@ class TestArgParse(unittest.TestCase):
         self.assertDictEqual(
             script_params["inputs"][""][0],
             {
-                "group": "optional arguments",
+                "group": OPTIONAL_TITLE,
                 "nodes": [
                     {
                         "model": "CharField",
@@ -231,7 +235,7 @@ class TestArgParse(unittest.TestCase):
                         "mutex_group": {},
                     }
                 ],
-                "group": "optional arguments",
+                "group": OPTIONAL_TITLE,
             },
         )
 
@@ -301,7 +305,7 @@ class TestArgParse(unittest.TestCase):
                         "checked": True,
                     },
                 ],
-                "group": "optional arguments",
+                "group": OPTIONAL_TITLE,
             },
         )
 

--- a/clinto/tests/test_parsers.py
+++ b/clinto/tests/test_parsers.py
@@ -183,6 +183,7 @@ class TestArgParse(unittest.TestCase):
         self.assertEquals("", parser.error)
 
     def test_can_exclude_bad_imports(self):
+        self.maxDiff = None
         script_path = os.path.join(self.script_dir, "error_script.py")
         parser = Parser(script_path=script_path, ignore_bad_imports=True)
         self.assertEquals("", parser.error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 coveralls
-nose
+pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,0 @@
-[tox]
-envlist = py27,py35,py36
-[testenv]
-deps=nose
-commands=nosetests


### PR DESCRIPTION
This lets us ignore a bad import, which is useful if we are running this script from a webserver and running the actual script in a virtualenv.